### PR TITLE
Pypi naming

### DIFF
--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -56,6 +56,7 @@ In this episode we will only be creating a minimal example so many of the files 
 📦 fibonacci_uos_name/
 ├── 📂 fibonacci_uos_name/
 │   └── 📄 sequence.py
+│   └── 📄 __init__.py
 ├── 📄 pyproject.toml
 └── 📂 tests/
     └── 📄 test_fibonacci.py

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -87,11 +87,11 @@ def compute(n_terms):
 ::: challenge
 ### Using your Python module
 
-Create a script in your project directory that imports and uses your Fibonacci script. This will serve as a good quick test that it works.
+Create a script in your project directory that imports and uses your sequence script. This will serve as a good quick test that it works.
 
 ::: solution
 1. Create the file in the project folder `/fibonacci_uos_name`, for example `use_fibonacci.py`.
-2. Import and run the Fibonacci function:
+2. Import and run the compute function:
 ```python
 from fibonacci_uos_name.sequence import compute
 

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -93,7 +93,7 @@ Create a script in your project directory that imports and uses your Fibonacci s
 1. Create the file in the project folder `/fibonacci_uos_name`, for example `use_fibonacci.py`.
 2. Import and run the Fibonacci function:
 ```python
-from fibonacci.sequence import compute
+from fibonacci_uos_name.sequence import compute
 
 compute(5)
 ```

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -111,7 +111,7 @@ requires = ["setuptools"]
 
 
 [project]
-name = "fibonacci"
+name = "fibonacci_uos_name"
 version = "0.1.0"
 description = "A package to calculate the fibonacci sequence"
 dependencies = ["pandas", "numpy"]

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -87,15 +87,31 @@ def compute(n_terms):
 ::: challenge
 ### Using your Python module
 
-Create a script in your project directory that imports and uses your sequence script. This will serve as a good quick test that it works.
+With your Python environment activate, launch Python and test importing and using your package.
 
 ::: solution
-1. Create the file in the project folder `/fibonacci_uos_name`, for example `use_fibonacci.py`.
-2. Import and run the compute function:
+**1. Navigate to a different directory to ensure you are importing the package not the local directory**
+
+```bash
+cd ../..
+```
+
+**2. Launch Python and import package**
+
+```bash 
+python
+```
 ```python
 from fibonacci_uos_name.sequence import compute
 
 compute(5)
+```
+
+or
+```python
+import fibonacci_uos_name.sequence
+
+fibonacci_uos_name.sequence.compute(5)
 ```
 :::
 :::

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -147,7 +147,7 @@ Create a `pyproject.toml` file with the two required tables. In the `[project]` 
 requires = ["setuptools"]
 
 [project]
-name = "fibonacci"
+name = "fibonacci_uos_name"
 version = "0.1.0"
 description = "A package which can produce the Fibonacci sequence"
 authors = [{name = "your_name", email="youremail@email.com"}]

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -46,7 +46,6 @@ Think back to the earlier episodes and try to recall all the things that can go 
 1. Python Module - This is the directory with the Python code that does the work.
 2. Configuration File - e.g. your pyproject.toml file
 3. Other metadata files - e.g. LICENCE, README.md, citation.cff
-4. Python Tests - A directory full of unit-tests and other tests
 :::
 :::
 
@@ -57,9 +56,7 @@ In this episode we will only be creating a minimal example so many of the files 
 ├── 📂 fibonacci_uos_name/
 │   └── 📄 sequence.py
 │   └── 📄 __init__.py
-├── 📄 pyproject.toml
-└── 📂 tests/
-    └── 📄 test_fibonacci.py
+└── 📄 pyproject.toml
 ```
 
 The first thing we will do in this project is create the Python module (the actual code!).

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -50,12 +50,12 @@ Think back to the earlier episodes and try to recall all the things that can go 
 :::
 :::
 
-In this episode we will only be creating a minimal example so many of the files you have thought of won't be included. Next we will be creating our directory structure. In either your `documents` folder if you are on Windows or your `home` directory if you are on macOS or Linux, create a folder called `my_project` 
+In this episode we will only be creating a minimal example so many of the files you have thought of won't be included. Next we will be creating our directory structure. In either your `documents` folder if you are on Windows or your `home` directory if you are on macOS or Linux, create a folder called `fibonnaci_uos_name` 
 
 ```
-📦 my_project/
-├── 📂 my_package/
-│   └── 📄 fibonacci.py
+📦 fibonacci_uos_name/
+├── 📂 fibonacci_uos_name/
+│   └── 📄 sequence.py
 ├── 📄 pyproject.toml
 └── 📂 tests/
     └── 📄 test_fibonacci.py
@@ -66,10 +66,10 @@ The first thing we will do in this project is create the Python module (the actu
 ::: challenge
 ### Creating Python module
 
-1. Create a Python file called `fibonacci.py` as shown in the structure above.
+1. Create a Python file called `sequence.py` as shown in the structure above.
 2. Add the following code which contains a function that returns the Fibonacci sequence
 ```python
-def fibonacci(n_terms):
+def compute(n_terms):
   num1 = 0
   num2 = 1
   next_num = 1
@@ -89,12 +89,12 @@ def fibonacci(n_terms):
 Create a script in your project directory that imports and uses your Fibonacci script. This will serve as a good quick test that it works.
 
 ::: solution
-1. Create the file in `/my_project`, for example `fibonacci_test.py`.
+1. Create the file in the project folder `/fibonacci_uos_name`, for example `use_fibonacci.py`.
 2. Import and run the Fibonacci function:
 ```python
-from my_package.fibonacci import fibonacci
+from fibonacci.sequence import compute
 
-fibonacci(5)
+compute(5)
 ```
 :::
 :::

--- a/episodes/creating-packages.md
+++ b/episodes/creating-packages.md
@@ -158,6 +158,42 @@ keywords = ["fibonacci", "maths"]
 
 Running `python -m pip install .` will install your package. Just ensure your terminal's working directory is the same as the `pyproject.toml` file!
 
+### Project & Packaging Naming
+
+Referring back to the project structure:
+```
+📦 my_project/
+├── 📂 my_package/
+│   └── 📄 my_code.py
+│   └── 📄 __init__.py
+└── 📄 pyproject.toml
+```
+
+The name of your package directory is the name that users will import when they use the package
+
+```python
+from my_package.my_code import my_func
+
+my_func()
+```
+
+PyPI which we looked at in the [accessing packages](accessing-packages.md) episode and other tools like build which we cover later, use the project name specified in your pyproject.toml. It is common to keep these names consistent, so the package name the user installs is the same that is used to import the package.
+
+:::callout
+### Package Name Discrepency
+
+Some packages do not use the same name, one famous example is pillow. The project name is pillow but the package you import inside is PIL.
+
+```bash
+pip install pillow
+```
+
+```python
+from PIL import Image
+```
+:::
+
+
 ::: callout
 ### Editable Install
 When installing your own package locally, there is an option called editable or `-e` for short.

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -108,6 +108,8 @@ The most basic directory structure of a Python package looks something like:
 ```
 📦 my_project/
 ├── 📂 my_package/
+│   └── 📄 my_code.py
+│   └── 📄 __init__.py
 └── 📄 pyproject.toml
 
 where
@@ -124,16 +126,7 @@ Tools such as `setuptools` and `pip` use the `pyproject.toml` file to configure 
 
 ### Optional: What is `__init__.py`?
 
-At this point, it's worth discussing the use of the `__init__.py` file that you might have come across before when packaging. Historically, the `__init__.py` script has been used to mark a directory as a Python package, allowing the contained modules to be imported (note; the use of double under lines in Python, often abbreviated to `dunder` lines, signal that this script should be "hidden" from users, helping distinguish this script from others.) It also contains any initialisation code for the package. The directory's structure might look something like:
-
-
-```
-📦 my_project/
-├── 📂 my_package/
-│   └── 📄 __init__.py
-└── 📄 pyproject.toml
-```
-
+At this point, it's worth discussing the use of the `__init__.py` file. The `__init__.py` script is used to mark a directory as a Python package (different to a sotware package), allowing the contained modules to be imported (note; the use of double under lines in Python, often abbreviated to `dunder` lines, signal that this script should be "hidden" from users, helping distinguish this script from others). It also contains any initialisation code for the package
 For instance, consider the times you have imported a package, such as [numpy](www.numpy.org). The ability to write:
 
 ```Python
@@ -141,8 +134,7 @@ import numpy
 ```
 is enabled by the modular structuring of the numpy package. This includes presence of the `__init__.py` file, which signals to Python that the directory is a package, allowing to import its content using the `import` statement. The complete `import numpy` statement then means Python searches for the `numpy` package  in its search path (`sys.path`) and loads its contents into the namespace under the name `numpy`. Packages that follow the folder structure above are often referred to as **regular packages**.
 
-However, in Python versions >= 3.3, the concept of **implicit namespace packages** (see [PEP 420](https://peps.Python.org/pep-0420/)) was introduced. Namespace packages are commonly used to split a regular Python package (as described above) across multiple directories, which ultimately means the `__init__.py` file is technically not required to create any Python package. For the purposes of this course, we will omit the use of the `__init__.py` script.
-
+However, in Python versions >= 3.3, the concept of **implicit namespace packages** (see [PEP 420](https://peps.Python.org/pep-0420/)) was introduced. Namespace packages are commonly used to split a regular Python package (as described above) across multiple directories, which ultimately means the `__init__.py` file is technically not required to create any Python package. For the purposes of this course, we will use an `__init__.py` to keep with convention and avoid complications with namespace packages.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/versioning.md
+++ b/episodes/versioning.md
@@ -159,7 +159,7 @@ requires = ["setuptools", "setuptools-scm"]
 
 
 [project]
-name = "fibonacci"
+name = "fibonacci_uos_name"
 description = "A package to calculate the fibonacci sequence"
 dependencies = ["pandas", "numpy"]
 dynamic = ["version"]


### PR DESCRIPTION
Merge #46 first

This PR : 
- Adds a small section explicitly discussing the difference between the package name and the project name.
- Updates the 'using your python module' example to use a python session rather than a script.
- Defaults to using standard Python packages (__init__.py) over namespace packages.
- Updates the package name to be unique, so when we upload to PyPI in episode 6 the package name will be valid.